### PR TITLE
Added the kaminari gem, tables are now paginated but with a problem.'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem 'httparty'
 gem 'nokogiri'
 # to enable byebug
 gem 'rb-readline'
+# for pagination
+gem 'kaminari'
+
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,18 @@ GEM
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -209,6 +221,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   httparty
   jbuilder (~> 2.5)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   nokogiri
   pg (>= 0.18, < 2.0)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 class HomeController < ApplicationController
   def index
     # Seperate each category of products into their own global variable for easier modification.
-    @registered_products = Product.where(product_type: 0)
-    @unregistered_products = Product.where(product_type: 1)
+    @registered_products = Product.where(product_type: 0).page params[:page]
+    @unregistered_products = Product.where(product_type: 1).page params[:page]
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,5 @@
 class Product < ApplicationRecord
     enum product_type: [:registered, :unregistered, :cosmetic]
+
+    paginates_per 8
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,6 @@
-<h1>Registered Products</h1>
+<h2>Registered Products</h2>
 <%= render partial: "registered" %>
+<%= paginate @registered_products %>
 <h2>Unregistered Products</h2>
 <%= render partial: "unregistered" %>
+<%= paginate @unregistered_products %>


### PR DESCRIPTION
The problem being that both the registered and unregistered products table will load pagination at the same time. For example, if I click on 2 on the registered table, the unregistered table will also load 2. This is most probably because the data for both tables come from the same objects.