### PR TITLE
Fixed the issue with the pagination, changed the query params.

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 class HomeController < ApplicationController
   def index
     # Seperate each category of products into their own global variable for easier modification.
-    @registered_products = Product.where(product_type: 0).page params[:page]
-    @unregistered_products = Product.where(product_type: 1).page params[:page]
+    @registered_products = Product.where(product_type: 0).page params[:registered_page_no]
+    @unregistered_products = Product.where(product_type: 1).page params[:unregistered_page_no]
   end
 end

--- a/app/views/home/_registered.html.erb
+++ b/app/views/home/_registered.html.erb
@@ -14,3 +14,4 @@
         <% end %>
     </tbody>
 </table>
+<%= paginate @registered_products, param_name: :registered_page_no %>

--- a/app/views/home/_unregistered.html.erb
+++ b/app/views/home/_unregistered.html.erb
@@ -14,3 +14,4 @@
         <% end %>
     </tbody>
 </table>
+<%= paginate @unregistered_products, param_name: :unregistered_page_no %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,4 @@
 <h2>Registered Products</h2>
 <%= render partial: "registered" %>
-<%= paginate @registered_products %>
 <h2>Unregistered Products</h2>
 <%= render partial: "unregistered" %>
-<%= paginate @unregistered_products %>


### PR DESCRIPTION
The problem was in the way I named my parameters for the links. Initially, it was this...
_Home controller, index method_
`@registered_products = Product.where(product_type: 0).page params[:page]
  @unregistered_products = Product.where(product_type: 1).page params[:page]`
My params for the pagination links were both the same, **params[:page]**, this resulted in both tables changing to the same pagination link when either one was clicked.
The solution was to give each query param a different name.
_Home controller, index method, changed_
`@registered_products = Product.where(product_type: 0).page params[:registered_page_no]
  @unregistered_products = Product.where(product_type: 1).page params[:unregistered_page_no]`
Also, specify the params when paginating in the view.
`<%= paginate @registered_products, param_name: :registered_page_no %>`
`<%= paginate @unregistered_products, param_name: :unregistered_page_no %>`
The solution was found on [Stack Overflow](https://stackoverflow.com/questions/54955374/paginating-multiple-objects-of-the-same-model-on-the-same-page-with-kaminari).